### PR TITLE
Update script for Alpine 3.17, Oracle 21 + ODBC

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,15 @@
 FROM alpine:latest
 
-RUN apk --no-cache add libaio libnsl libc6-compat curl && \
+RUN apk --no-cache add libaio libc6-compat gcompat && \
     cd /tmp && \
-    curl -o instantclient-basiclite.zip https://download.oracle.com/otn_software/linux/instantclient/instantclient-basiclite-linuxx64.zip -SL && \
-    unzip instantclient-basiclite.zip && \
+    wget -qO instantclient-basiclite.zip https://download.oracle.com/otn_software/linux/instantclient/instantclient-basiclite-linuxx64.zip && \
+    wget -qO instantclient-odbc.zip https://download.oracle.com/otn_software/linux/instantclient/instantclient-odbc-linuxx64.zip && \
+    unzip -q instantclient-basiclite.zip && \
+    unzip -q instantclient-odbc.zip && \
     mv instantclient*/ /usr/lib/instantclient && \
-    rm instantclient-basiclite.zip && \
-    ln -s /usr/lib/instantclient/libclntsh.so.21.1 /usr/lib/libclntsh.so && \
-    ln -s /usr/lib/instantclient/libocci.so.21.1 /usr/lib/libocci.so && \
-    ln -s /usr/lib/instantclient/libociicus.so /usr/lib/libociicus.so && \
-    ln -s /usr/lib/instantclient/libnnz21.so /usr/lib/libnnz21.so && \
-    ln -s /usr/lib/libnsl.so.2 /usr/lib/libnsl.so.1 && \
+    rm instantclient-basiclite.zip instantclient-odbc.zip && \
     ln -s /lib/libc.so.6 /usr/lib/libresolv.so.2 && \
-    ln -s /lib64/ld-linux-x86-64.so.2 /usr/lib/ld-linux-x86-64.so.2
+    /usr/lib/instantclient/odbc_update_ini.sh / /usr/lib/instantclient
+# TODO: libresolv fixed by gcompat in Alpine 3.18
 
 ENV LD_LIBRARY_PATH /usr/lib/instantclient


### PR DESCRIPTION
It still missing some symbols but they can be easily stubbed (they only called on edge cases, probably never)
Export this symbols from any lib in process (or via `LD_PRELOAD`)
```c++
#ifndef WIN32

#include <features.h>
#ifndef __USE_GNU // probably musl

#include <sys/types.h>
#include <netinet/in.h>
#include <resolv.h>
#include <stdio.h>
#include <stdlib.h>
#include <math.h>

// glibc stubs for Oracle OCI compat on Alpine
extern "C" {
#pragma GCC visibility push(default)
int __dn_expand(const unsigned char *msg, const unsigned char *eomorig, const unsigned char *comp_dn, char *exp_dn, int length) { exit(90); }
int __dn_skipname(const u_char *comp_dn, const u_char *eom) { exit(90); }
void __res_nclose(res_state statep) { exit(90); }
int __res_ninit(res_state statep) { exit(90); }
int __res_nsearch(res_state statep, const char *dname, int class, int type, unsigned char *answer, int anslen) { exit(90); }

int __finite(double x) { return isfinite(x); }
int __fprintf_chk(FILE* stream, const char* format, ...) { exit(90); }
int __printf_chk(const char* format, ...) { exit(90); }
// Apache 2.0 // https://android.googlesource.com/platform/bionic/+/e0959b4b164a26eb9931ed6925c71d7870c063fe/libc/bionic/__vsprintf_chk.cpp
int __vsprintf_chk(char* dest, int /*flags*/, size_t dest_len_from_compiler, const char* format, va_list va) {
  int result = vsnprintf(dest, dest_len_from_compiler, format, va);
  if ((size_t) result >= dest_len_from_compiler) {
    exit(100); // ("vsprintf: prevented write past end of buffer", 0);
  }
  return result;
}

char **backtrace_symbols(void *const *buffer, int size) { exit(90); }
int backtrace(void **buffer, int size) { exit(90); }

int bindresvport(int sockfd, struct sockaddr_in *sin) { exit(90); }
char* canonicalize_file_name(const char* path) { return realpath(path, NULL); }
struct __ucontext {};
int getcontext(__ucontext* ) { exit(90); }
#pragma GCC visibility pop
}

#endif // musl

#endif
```